### PR TITLE
Change to new db schema and integrate seasons

### DIFF
--- a/src/components/HexShotchart/index.js
+++ b/src/components/HexShotchart/index.js
@@ -129,7 +129,7 @@ class ShotChart extends React.Component {
 
 ShotChart.propTypes = {
   data: PropTypes.arrayOf(
-    PropTypes.exact({
+    PropTypes.shape({
       id: PropTypes.number.isRequired,
       game_id: PropTypes.number.isRequired,
       game_event_id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
@@ -137,7 +137,7 @@ ShotChart.propTypes = {
       distance: PropTypes.number.isRequired,
       x: PropTypes.number.isRequired,
       y: PropTypes.number.isRequired,
-      made_flag: PropTypes.bool.isRequired,
+      made: PropTypes.bool.isRequired,
     })
   ).isRequired,
   hover: PropTypes.exact({

--- a/src/components/Hexagons/index.js
+++ b/src/components/Hexagons/index.js
@@ -14,7 +14,7 @@ function Hexagons(props) {
     scale,
     updateTooltip,
   } = props;
-  const shots = data.map(shot => [shot.x, shot.y, shot.made_flag]);
+  const shots = data.map(shot => [shot.x, shot.y, shot.made]);
 
   return (
     hexbinPath(shots)

--- a/src/components/PlayerSelector/index.js
+++ b/src/components/PlayerSelector/index.js
@@ -18,7 +18,7 @@ const PlayerSelector = ({player, players, setPlayerId}) => {
         >
           {players.map(d => (
             <option key={d.id} value={d.id}>
-              {d.name}
+              {d.name_first_last}
             </option>
           ))}
         </select>
@@ -30,9 +30,10 @@ const PlayerSelector = ({player, players, setPlayerId}) => {
 PlayerSelector.propTypes = {
   player: PropTypes.number.isRequired,
   players: PropTypes.arrayOf(
-    PropTypes.exact({
+    PropTypes.shape({
       id: PropTypes.number.isRequired,
-      name: PropTypes.string.isRequired,
+      name_last_first: PropTypes.string.isRequired,
+      name_first_last: PropTypes.string.isRequired,
     })
   ).isRequired,
   setPlayerId: PropTypes.func.isRequired,

--- a/src/components/PlayerSelector/index.js
+++ b/src/components/PlayerSelector/index.js
@@ -6,13 +6,14 @@ const PlayerSelector = ({player, players, setPlayerId}) => {
   const history = useHistory();
   return (
     <form>
-      <label htmlFor="select1">
-        Select
+      <label htmlFor="playerselector">
+        Player{' '}
         <select
+          id="playerselector"
           value={player}
           onChange={e => {
             const playerId = parseInt(e.target.value);
-            history.push(`/players/${playerId}`);
+            history.push(`/players/${playerId}${history.location.search}`);
             setPlayerId(playerId);
           }}
         >

--- a/src/components/SeasonSelector/index.js
+++ b/src/components/SeasonSelector/index.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {useHistory} from 'react-router-dom';
+
+const SeasonSelector = ({player, season, seasons, setSeasonId}) => {
+  const history = useHistory();
+  return (
+    <form>
+      <label htmlFor="seasonselector">
+        Season{' '}
+        <select
+          id="seasonselector"
+          value={season}
+          onChange={e => {
+            const seasonId = parseInt(e.target.value);
+            history.push(`/players/${player}?season_id=${seasonId}`);
+            setSeasonId(seasonId);
+          }}
+        >
+          {seasons.map(d => (
+            <option key={d.id} value={d.id}>
+              {d.string}
+            </option>
+          ))}
+        </select>
+      </label>
+    </form>
+  );
+};
+
+SeasonSelector.propTypes = {
+  player: PropTypes.number.isRequired,
+  season: PropTypes.number.isRequired,
+  seasons: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      string: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+  setSeasonId: PropTypes.func.isRequired,
+};
+
+export default SeasonSelector;

--- a/src/containers/ChartDashboard/index.js
+++ b/src/containers/ChartDashboard/index.js
@@ -3,20 +3,36 @@ import {useRouteMatch} from 'react-router-dom';
 
 import Charts from '../Charts';
 import PlayerSelector from '../../components/PlayerSelector';
-import {usePlayersApi} from '../../hooks';
+import SeasonSelector from '../../components/SeasonSelector';
+import {
+  usePlayersWithRostersBySeasonApi,
+  useSeasonsApi,
+  useUrlSearchParams,
+} from '../../hooks';
 
 export default function ChartDashboard() {
-  const [players] = usePlayersApi();
   const match = useRouteMatch('/players/:playerId');
+  const urlSearchParams = useUrlSearchParams();
+  const slugSeasonId = parseInt(urlSearchParams.get('season_id'));
   const slugPlayerId =
     match && match.params ? parseInt(match.params.playerId) : 2544;
+  const [seasons] = useSeasonsApi(slugPlayerId);
+  const [seasonId, setSeasonId] = useState(slugSeasonId || 2019);
+  const [players] = usePlayersWithRostersBySeasonApi(seasonId);
   const [playerId, setPlayerId] = useState(slugPlayerId);
 
   if (slugPlayerId && slugPlayerId !== playerId) {
     setPlayerId(slugPlayerId);
   }
+  if (
+    seasons?.[0]?.id &&
+    seasons[0].id !== seasonId &&
+    Number.isNaN(slugSeasonId)
+  ) {
+    setSeasonId(seasons?.[0].id);
+  }
 
-  if (players === undefined) {
+  if (players === undefined || seasons === undefined) {
     return <div>Still fetching data</div>;
   }
   if (players.length === 0) {
@@ -30,7 +46,13 @@ export default function ChartDashboard() {
         players={players}
         setPlayerId={setPlayerId}
       />
-      <Charts playerId={playerId} />
+      <SeasonSelector
+        player={playerId}
+        season={seasonId}
+        seasons={seasons}
+        setSeasonId={setSeasonId}
+      />
+      <Charts playerId={playerId} seasonId={seasonId} />
     </div>
   );
 }

--- a/src/containers/Charts/index.js
+++ b/src/containers/Charts/index.js
@@ -16,12 +16,16 @@ const ChartsDiv = styled.div`
   ${media.tablet`flex-direction: column;`}
 `;
 
-const Charts = ({playerId}) => {
+const Charts = ({playerId, seasonId}) => {
   const maxDistance = 35;
   const [activated, setActivated] = useState(0);
   const [deactivated, setDeactivated] = useState(0);
   const [leagueShootingPct] = useLeagueShootingPctApi(maxDistance);
-  const [{data, ribbonedData, binnedData}] = useShotsApi(playerId, maxDistance);
+  const [{data, ribbonedData, binnedData}] = useShotsApi(
+    playerId,
+    seasonId,
+    maxDistance
+  );
 
   if (
     leagueShootingPct.length === 0 ||
@@ -69,6 +73,7 @@ const Charts = ({playerId}) => {
 
 Charts.propTypes = {
   playerId: PropTypes.number,
+  seasonId: PropTypes.number,
 };
 
 export default Charts;

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,3 +1,6 @@
 export {default as useLeagueShootingPctApi} from './useLeagueShootingPctApi';
 export {default as usePlayersApi} from './usePlayersApi';
+export {default as usePlayersWithRostersBySeasonApi} from './usePlayersWithRostersBySeasonApi';
 export {default as useShotsApi} from './useShotsApi';
+export {default as useSeasonsApi} from './useSeasonsApi';
+export {default as useUrlSearchParams} from './useUrlSearchParams';

--- a/src/hooks/usePlayersWithRostersBySeasonApi.js
+++ b/src/hooks/usePlayersWithRostersBySeasonApi.js
@@ -1,0 +1,26 @@
+import {useEffect, useState} from 'react';
+import axios from 'axios';
+
+function usePlayersWithRostersBySeasonApi(seasonId = null) {
+  const [players, setPlayers] = useState([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const origin =
+        process.env.NODE_ENV === 'development'
+          ? 'http://localhost:5000'
+          : 'https://splash.jackfletch.com';
+
+      const endpoint = new URL(origin);
+      endpoint.pathname = `/api/playersWithRosters/${seasonId}`;
+
+      const result = await axios.get(endpoint);
+      setPlayers(result.data);
+    };
+    fetchData();
+  }, [seasonId]);
+
+  return [players];
+}
+
+export default usePlayersWithRostersBySeasonApi;

--- a/src/hooks/useSeasonsApi.js
+++ b/src/hooks/useSeasonsApi.js
@@ -1,0 +1,29 @@
+import {useEffect, useState} from 'react';
+import axios from 'axios';
+
+function useSeasonsApi(playerId) {
+  const [seasons, setSeasons] = useState([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const origin =
+        process.env.NODE_ENV === 'development'
+          ? 'http://localhost:5000'
+          : 'https://splash.jackfletch.com';
+
+      const endpoint = new URL(origin);
+      endpoint.pathname = '/api/seasons';
+      endpoint.search = new URLSearchParams({
+        player_id: playerId,
+      });
+
+      const result = await axios.get(endpoint);
+      setSeasons(result.data.reverse());
+    };
+    fetchData();
+  }, [playerId]);
+
+  return [seasons];
+}
+
+export default useSeasonsApi;

--- a/src/hooks/useShotsApi.js
+++ b/src/hooks/useShotsApi.js
@@ -2,24 +2,28 @@ import {useEffect, useState} from 'react';
 import axios from 'axios';
 import {binShots, ribbonShots} from '@jackfletch/splash-vis-utils';
 
-function useShotsApi(playerId, maxDistance) {
+function useShotsApi(playerId, seasonId, maxDistance) {
   const [data, setData] = useState(undefined);
   const [ribbonedData, setRibbonedData] = useState([]);
   const [binnedData, setBinnedData] = useState({});
 
   useEffect(() => {
     const fetchData = async () => {
-      const endpoint =
+      const origin =
         process.env.NODE_ENV === 'development'
-          ? `http://localhost:5000/api/shots/${playerId}`
-          : `https://splash.jackfletch.com/api/shots/${playerId}`;
+          ? 'http://localhost:5000'
+          : 'https://splash.jackfletch.com';
+
+      const endpoint = new URL(origin);
+      endpoint.pathname = `/api/shots/player/${playerId}/season/${seasonId}`;
+
       const res = await axios.get(endpoint);
       setData(res.data);
       setRibbonedData(ribbonShots(res.data, maxDistance));
       setBinnedData(binShots(res.data, maxDistance));
     };
     fetchData();
-  }, [playerId, maxDistance]);
+  }, [playerId, seasonId, maxDistance]);
 
   return [{data, ribbonedData, binnedData}];
 }

--- a/src/hooks/useUrlSearchParams.js
+++ b/src/hooks/useUrlSearchParams.js
@@ -1,0 +1,7 @@
+import {useLocation} from 'react-router-dom';
+
+function useUrlSearchParams() {
+  return new URLSearchParams(useLocation().search);
+}
+
+export default useUrlSearchParams;


### PR DESCRIPTION
A new db schema was required to integrate seasons. This PR adapts to the new schema and adds a season endpoint `useSeasonsApi` to list each active season for a given player. Additionally, this PR adds a season selector component, `seasonId` URL parsing, and an additional endpoint `usePlayersWithRostersBySeasonApi` (could use a simpler name) to get players that were active in a given season.

Closes: #9 