### PR TITLE
Refactor hover state to React context

### DIFF
--- a/src/components/BarChart/Cursor.js
+++ b/src/components/BarChart/Cursor.js
@@ -2,17 +2,22 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
+import {useHoverState} from '../../hooks';
+
 const Text = styled.text`
   font-size: ${props => (props.main ? 1 : 0.875)}rem;
   text-anchor: ${props => props.textAnchor};
 `;
 
 const Cursor = props => {
-  const {x, datum, labeler, totalShots} = props;
+  const {datum, labeler, scale, totalShots} = props;
+  const hover = useHoverState();
+
+  const x = scale.x(hover.distance + 0.5);
   let xLoc;
   let newTextAnchor;
 
-  if (datum.x < 30) {
+  if (hover.distance < 30) {
     xLoc = x + 10;
     newTextAnchor = 'start';
   } else {
@@ -23,37 +28,41 @@ const Cursor = props => {
   const {counts, pct} = labeler(totalShots)(datum);
   const pctText = `${pct}%`;
   const countText = `~ ${counts.num} / ${counts.denom}`;
-  const distanceText = `@ ${datum.x} ft`;
+  const distanceText = `@ ${hover.distance} ft`;
 
   return (
-    <g>
-      <Text main x={xLoc} y={32} textAnchor={newTextAnchor}>
-        {pctText}
-      </Text>
-      <Text x={xLoc} y={50} textAnchor={newTextAnchor}>
-        {countText}
-      </Text>
-      <Text x={xLoc} y={68} textAnchor={newTextAnchor}>
-        {distanceText}
-      </Text>
-      <path
-        d={`M${x},250 L${x},20`}
-        style={{
-          strokeWidth: 10,
-          stroke: 'rgba(0, 0, 0, 0.2)',
-        }}
-      />
-    </g>
+    hover.toggle && (
+      <g>
+        <Text main x={xLoc} y={32} textAnchor={newTextAnchor}>
+          {pctText}
+        </Text>
+        <Text x={xLoc} y={50} textAnchor={newTextAnchor}>
+          {countText}
+        </Text>
+        <Text x={xLoc} y={68} textAnchor={newTextAnchor}>
+          {distanceText}
+        </Text>
+        <path
+          d={`M${x},250 L${x},20`}
+          style={{
+            strokeWidth: 10,
+            stroke: 'rgba(0, 0, 0, 0.2)',
+          }}
+        />
+      </g>
+    )
   );
 };
 
 Cursor.propTypes = {
-  x: PropTypes.number,
   datum: PropTypes.shape({
-    x: PropTypes.number.isRequired,
     total: PropTypes.number.isRequired,
   }),
   labeler: PropTypes.func.isRequired,
+  scale: PropTypes.shape({
+    x: PropTypes.func.isRequired,
+    y: PropTypes.func.isRequired,
+  }),
   totalShots: PropTypes.number.isRequired,
 };
 

--- a/src/components/BarChart/index.js
+++ b/src/components/BarChart/index.js
@@ -108,7 +108,7 @@ const BarChart = props => {
   const yScale = scaleLinear()
     .domain([0, 1])
     .range([height, 0]);
-  const scales = {
+  const scale = {
     x: xScale,
     y: yScale,
   };
@@ -175,14 +175,12 @@ const BarChart = props => {
             standalone={false}
             style={styles.lineOne}
           />
-          {hover.toggle && hover.distance >= 0 && (
-            <Cursor
-              x={scales.x(hover.distance + 0.5)}
-              datum={{x: hover.distance, ...data.bins[hover.distance]}}
-              totalShots={data.totalShots}
-              labeler={label}
-            />
-          )}
+          <Cursor
+            datum={{...data.bins[hover.distance]}}
+            totalShots={data.totalShots}
+            labeler={label}
+            scale={scale}
+          />
         </VictoryChart>
       </Div2>
     </ChartDiv>

--- a/src/components/BarChart/index.js
+++ b/src/components/BarChart/index.js
@@ -10,6 +10,7 @@ import {
   VictoryVoronoiContainer,
 } from 'victory';
 
+import {useHover} from '../../hooks';
 import theme from '../victorytheme';
 import ChartDiv from '../ChartDiv';
 import ChartTitle from '../ChartTitle';
@@ -96,18 +97,10 @@ PercentAxisTickLabel.propTypes = {
 };
 
 const BarChart = props => {
-  const {
-    data,
-    domain,
-    hover,
-    label,
-    maxDistance,
-    setActivated,
-    setDeactivated,
-    title,
-    y,
-  } = props;
+  const {data, domain, label, maxDistance, title, y} = props;
   const {height, padding, width} = theme.area;
+
+  const [hover, dispatchHover] = useHover();
 
   const xScale = scaleLinear()
     .domain([0, maxDistance])
@@ -135,18 +128,17 @@ const BarChart = props => {
             <VictoryVoronoiContainer
               voronoiDimension="x"
               onActivated={points => {
-                setActivated(points[0].x);
+                dispatchHover({type: 'activate', value: points[0].x});
               }}
               onDeactivated={points => {
                 if (points.length) {
-                  setDeactivated(points[0].x);
+                  dispatchHover({type: 'deactivate', value: points[0].x});
                 }
               }}
               events={{
                 onMouseOut: () => {
                   if (!hover.toggle) {
-                    setActivated(-15);
-                    setDeactivated(-15);
+                    dispatchHover({type: 'reset'});
                   }
                 },
               }}
@@ -210,14 +202,8 @@ BarChart.propTypes = {
     totalShotsWithinMaxDistance: PropTypes.number.isRequired,
   }).isRequired,
   domain: PropTypes.arrayOf(PropTypes.number),
-  hover: PropTypes.exact({
-    distance: PropTypes.number.isRequired,
-    toggle: PropTypes.bool.isRequired,
-  }).isRequired,
   label: PropTypes.func.isRequired,
   maxDistance: PropTypes.number.isRequired,
-  setActivated: PropTypes.func.isRequired,
-  setDeactivated: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
   y: PropTypes.func.isRequired,
 };

--- a/src/components/HexShotchart/ShotchartCursor.js
+++ b/src/components/HexShotchart/ShotchartCursor.js
@@ -1,21 +1,28 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const ShotchartCursor = ({hoverDistance, scale}) => (
-  <ellipse
-    clipPath="url(#clip)"
-    cx={scale.x(0)}
-    cy={scale.y(0)}
-    rx={scale.x((hoverDistance + 0.5) * 10) - scale.x(0)}
-    ry={scale.y(0) - scale.y((hoverDistance + 0.5) * 10)}
-    strokeWidth={10}
-    fill="none"
-    stroke="rgba(0, 0, 0, 0.2)"
-  />
-);
+import {useHoverState} from '../../hooks';
+
+const ShotchartCursor = ({scale}) => {
+  const hover = useHoverState();
+
+  return (
+    hover.toggle && (
+      <ellipse
+        clipPath="url(#clip)"
+        cx={scale.x(0)}
+        cy={scale.y(0)}
+        rx={scale.x((hover.distance + 0.5) * 10) - scale.x(0)}
+        ry={scale.y(0) - scale.y((hover.distance + 0.5) * 10)}
+        strokeWidth={10}
+        fill="none"
+        stroke="rgba(0, 0, 0, 0.2)"
+      />
+    )
+  );
+};
 
 ShotchartCursor.propTypes = {
-  hoverDistance: PropTypes.number.isRequired,
   scale: PropTypes.shape({
     x: PropTypes.func.isRequired,
     y: PropTypes.func.isRequired,

--- a/src/components/HexShotchart/index.js
+++ b/src/components/HexShotchart/index.js
@@ -5,7 +5,6 @@ import {hexbin} from 'd3-hexbin';
 import {scaleLinear, scaleSequential, scaleSqrt} from 'd3-scale';
 import {interpolatePlasma} from 'd3-scale-chromatic';
 
-import {useHoverState} from '../../hooks';
 import Court from '../Court';
 import ChartDiv from '../ChartDiv';
 import Hexagons from '../Hexagons';
@@ -22,7 +21,6 @@ const Svg = styled.svg`
 
 const ShotChart = props => {
   const {data, leagueShootingPct} = props;
-  const hover = useHoverState();
   const [tooltip, setTooltip] = useState({
     color: 'none',
     makes: '',
@@ -89,9 +87,7 @@ const ShotChart = props => {
               updateTooltip={setTooltip}
             />
           </g>
-          {hover.toggle && hover.distance >= 0 ? (
-            <ShotchartCursor hoverDistance={hover.distance} scale={scales} />
-          ) : null}
+          <ShotchartCursor scale={scales} />
           {tooltip.show ? <Tooltip vals={tooltip} /> : null}
         </g>
       </Svg>

--- a/src/components/HexShotchart/index.js
+++ b/src/components/HexShotchart/index.js
@@ -5,6 +5,7 @@ import {hexbin} from 'd3-hexbin';
 import {scaleLinear, scaleSequential, scaleSqrt} from 'd3-scale';
 import {interpolatePlasma} from 'd3-scale-chromatic';
 
+import {useHoverState} from '../../hooks';
 import Court from '../Court';
 import ChartDiv from '../ChartDiv';
 import Hexagons from '../Hexagons';
@@ -20,6 +21,8 @@ const Svg = styled.svg`
 `;
 
 const ShotChart = props => {
+  const {data, leagueShootingPct} = props;
+  const hover = useHoverState();
   const [tooltip, setTooltip] = useState({
     color: 'none',
     makes: '',
@@ -54,8 +57,6 @@ const ShotChart = props => {
   const hexbinPath = hexbin()
     .size([width, height])
     .radius(hexbinSize);
-
-  const {data, hover, leagueShootingPct} = props;
 
   return (
     <ChartDiv>
@@ -111,10 +112,6 @@ ShotChart.propTypes = {
       made: PropTypes.bool.isRequired,
     })
   ).isRequired,
-  hover: PropTypes.exact({
-    distance: PropTypes.number.isRequired,
-    toggle: PropTypes.bool.isRequired,
-  }).isRequired,
   leagueShootingPct: PropTypes.arrayOf(PropTypes.number).isRequired,
 };
 

--- a/src/components/ShootingSignature/Cursor.js
+++ b/src/components/ShootingSignature/Cursor.js
@@ -1,16 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Cursor = ({scale, x}) => {
+import {useHoverState} from '../../hooks';
+
+const Cursor = ({scale}) => {
+  const hover = useHoverState();
+  const x = scale.x(hover.distance + 0.5);
   const top = scale.y(1);
   const bottom = scale.y(0);
   return (
-    <g>
-      <path
-        d={`M${scale.x(x + 0.5)},${top} L${scale.x(x + 0.5)},${bottom}`}
-        style={{strokeWidth: 10, stroke: 'rgba(0, 0, 0, 0.2)'}}
-      />
-    </g>
+    hover.toggle && (
+      <g>
+        <path
+          d={`M${x},${top} L${x},${bottom}`}
+          style={{strokeWidth: 10, stroke: 'rgba(0, 0, 0, 0.2)'}}
+        />
+      </g>
+    )
   );
 };
 
@@ -19,7 +25,6 @@ Cursor.propTypes = {
     x: PropTypes.func.isRequired,
     y: PropTypes.func.isRequired,
   }),
-  x: PropTypes.number.isRequired,
 };
 
 export default Cursor;

--- a/src/components/ShootingSignature/index.js
+++ b/src/components/ShootingSignature/index.js
@@ -5,6 +5,7 @@ import {interpolatePlasma} from 'd3-scale-chromatic';
 import {area, curveBasis} from 'd3-shape';
 import styled from 'styled-components';
 
+import {useHoverState} from '../../hooks';
 import ChartDiv from '../ChartDiv';
 import ChartTitle from '../ChartTitle';
 import Cursor from './Cursor';
@@ -63,7 +64,8 @@ const width = svgWidth - margin.left - margin.right;
 const height = svgHeight - margin.top - margin.bottom;
 
 const ShootingSignature = props => {
-  const {data, hover, leagueShootingPct, maxDistance} = props;
+  const {data, leagueShootingPct, maxDistance} = props;
+  const hover = useHoverState();
 
   const x = scaleLinear()
     .domain([0, maxDistance])
@@ -131,10 +133,6 @@ ShootingSignature.propTypes = {
       width: PropTypes.number.isRequired,
     })
   ).isRequired,
-  hover: PropTypes.exact({
-    distance: PropTypes.number.isRequired,
-    toggle: PropTypes.bool.isRequired,
-  }).isRequired,
   leagueShootingPct: PropTypes.arrayOf(PropTypes.number).isRequired,
   maxDistance: PropTypes.number.isRequired,
 };

--- a/src/components/ShootingSignature/index.js
+++ b/src/components/ShootingSignature/index.js
@@ -5,7 +5,6 @@ import {interpolatePlasma} from 'd3-scale-chromatic';
 import {area, curveBasis} from 'd3-shape';
 import styled from 'styled-components';
 
-import {useHoverState} from '../../hooks';
 import ChartDiv from '../ChartDiv';
 import ChartTitle from '../ChartTitle';
 import Cursor from './Cursor';
@@ -65,7 +64,6 @@ const height = svgHeight - margin.top - margin.bottom;
 
 const ShootingSignature = props => {
   const {data, leagueShootingPct, maxDistance} = props;
-  const hover = useHoverState();
 
   const x = scaleLinear()
     .domain([0, maxDistance])
@@ -115,9 +113,7 @@ const ShootingSignature = props => {
                   style={{fill: `url(#${gradientId})`}}
                 />
               </Gradient>
-              {hover.toggle ? (
-                <Cursor x={hover.distance} scale={{x, y}} />
-              ) : null}
+              <Cursor scale={{x, y}} />
             </g>
           </g>
         </Svg>

--- a/src/containers/Charts/index.js
+++ b/src/containers/Charts/index.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
@@ -9,7 +9,7 @@ import ShootingSignature from '../../components/ShootingSignature';
 import BarChart, {
   functions as barChartFunctions,
 } from '../../components/BarChart';
-import {useShotsApi, useLeagueShootingPctApi} from '../../hooks';
+import {HoverProvider, useShotsApi, useLeagueShootingPctApi} from '../../hooks';
 
 const ChartsDiv = styled.div`
   display: flex;
@@ -18,10 +18,10 @@ const ChartsDiv = styled.div`
   ${media.tablet`flex-direction: column;`}
 `;
 
+const withHoverProvider = children => <HoverProvider>{children}</HoverProvider>;
+
 const Charts = ({playerId, seasonId}) => {
   const maxDistance = 35;
-  const [activated, setActivated] = useState(0);
-  const [deactivated, setDeactivated] = useState(0);
   const [leagueShootingPct] = useLeagueShootingPctApi(maxDistance, seasonId);
   const [{data, ribbonedData, binnedData}] = useShotsApi(
     playerId,
@@ -44,42 +44,26 @@ const Charts = ({playerId, seasonId}) => {
     return <div>Not enough shots by this player for any meaningful data</div>;
   }
 
-  const hover = {
-    distance: activated,
-    toggle: activated !== deactivated,
-  };
-
-  return (
+  return withHoverProvider(
     <ChartsDiv>
-      <HexShotchart
-        data={data}
-        hover={hover}
-        leagueShootingPct={leagueShootingPct}
-      />
+      <HexShotchart data={data} leagueShootingPct={leagueShootingPct} />
       <ShootingSignature
         data={ribbonedData}
-        hover={hover}
         leagueShootingPct={leagueShootingPct}
         maxDistance={maxDistance}
       />
       <BarChart
         data={binnedData}
-        hover={hover}
         label={barChartFunctions.shotProportion.labeler}
         maxDistance={maxDistance}
-        setActivated={setActivated}
-        setDeactivated={setDeactivated}
         title="Shot Proportion by Distance"
         y={barChartFunctions.shotProportion.accessor}
       />
       <BarChart
         data={binnedData}
         domain={[0, 100]}
-        hover={hover}
         label={barChartFunctions.fieldGoalPercentage.labeler}
         maxDistance={maxDistance}
-        setActivated={setActivated}
-        setDeactivated={setDeactivated}
         title="Field Goal Percentage by Distance"
         y={barChartFunctions.fieldGoalPercentage.accessor}
       />

--- a/src/hooks/hoverContext.js
+++ b/src/hooks/hoverContext.js
@@ -1,0 +1,78 @@
+import React, {createContext, useContext, useReducer} from 'react';
+import PropTypes from 'prop-types';
+
+const HoverStateContext = createContext();
+const HoverDispatchContext = createContext();
+
+const defaultState = {
+  activated: -1,
+  deactivated: -1,
+  distance: -1,
+  toggle: false,
+};
+
+function hoverReducer(state, action) {
+  switch (action.type) {
+    case 'activate': {
+      const {value} = action;
+      return {
+        ...state,
+        activated: value,
+        distance: value,
+        toggle: value !== state.deactivated,
+      };
+    }
+    case 'deactivate': {
+      const {value} = action;
+      return {
+        ...state,
+        deactivated: value,
+        toggle: state.activated !== value,
+      };
+    }
+    case 'reset': {
+      return defaultState;
+    }
+    default: {
+      throw new Error(`Unhandled action type: ${action.type}`);
+    }
+  }
+}
+
+function HoverProvider({children}) {
+  const [state, dispatch] = useReducer(hoverReducer, defaultState);
+
+  return (
+    <HoverStateContext.Provider value={state}>
+      <HoverDispatchContext.Provider value={dispatch}>
+        {children}
+      </HoverDispatchContext.Provider>
+    </HoverStateContext.Provider>
+  );
+}
+
+HoverProvider.propTypes = {
+  children: PropTypes.node,
+};
+
+function useHoverState() {
+  const context = useContext(HoverStateContext);
+  if (context === undefined) {
+    throw new Error('useHoverState must be used within a HoverProvider');
+  }
+  return context;
+}
+
+function useHoverDispatch() {
+  const context = useContext(HoverDispatchContext);
+  if (context === undefined) {
+    throw new Error('useHoverDispatch must be used within a HoverProvider');
+  }
+  return context;
+}
+
+function useHover() {
+  return [useHoverState(), useHoverDispatch()];
+}
+
+export {HoverProvider, useHover, useHoverState, useHoverDispatch};

--- a/src/hooks/hoverContext.js
+++ b/src/hooks/hoverContext.js
@@ -5,8 +5,6 @@ const HoverStateContext = createContext();
 const HoverDispatchContext = createContext();
 
 const defaultState = {
-  activated: -1,
-  deactivated: -1,
   distance: -1,
   toggle: false,
 };
@@ -14,20 +12,15 @@ const defaultState = {
 function hoverReducer(state, action) {
   switch (action.type) {
     case 'activate': {
-      const {value} = action;
       return {
-        ...state,
-        activated: value,
-        distance: value,
-        toggle: value !== state.deactivated,
+        distance: action.value,
+        toggle: true,
       };
     }
     case 'deactivate': {
-      const {value} = action;
       return {
-        ...state,
-        deactivated: value,
-        toggle: state.activated !== value,
+        distance: state.distance,
+        toggle: state.distance !== action.value,
       };
     }
     case 'reset': {

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,3 +1,9 @@
+export {
+  HoverProvider,
+  useHover,
+  useHoverDispatch,
+  useHoverState,
+} from './hoverContext';
 export {default as useLeagueShootingPctApi} from './useLeagueShootingPctApi';
 export {default as usePlayersApi} from './usePlayersApi';
 export {default as usePlayersWithRostersBySeasonApi} from './usePlayersWithRostersBySeasonApi';


### PR DESCRIPTION
This PR simplifies hover logic and isolates its usage to the necessary components. Additionally, React context keeps prop drilling to a minimum.

Replaces: #13