### PR TITLE
Refactor HexShotchart child components

### DIFF
--- a/src/components/Court/index.js
+++ b/src/components/Court/index.js
@@ -1,13 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-function Court({
-  height,
-  lineColor = '#aaa',
-  scale,
-  strokeWidth = 1.667,
-  width,
-}) {
+const Court = ({lineColor = '#aaa', scale, strokeWidth = 1.667}) => {
   const dThreePointLine = [
     'M',
     scale.x(-220),
@@ -254,22 +248,16 @@ function Court({
           }
         />
       ))}
-
-      <clipPath id="clip">
-        <rect className="mesh" width={width} height={height} />
-      </clipPath>
     </g>
   );
-}
+};
 
 Court.propTypes = {
-  width: PropTypes.number.isRequired,
-  height: PropTypes.number.isRequired,
+  lineColor: PropTypes.string,
   scale: PropTypes.shape({
     x: PropTypes.func,
     y: PropTypes.func,
   }).isRequired,
-  lineColor: PropTypes.string,
   strokeWidth: PropTypes.number,
 };
 

--- a/src/components/HexShotchart/ShotchartCursor.js
+++ b/src/components/HexShotchart/ShotchartCursor.js
@@ -9,7 +9,6 @@ const ShotchartCursor = ({scale}) => {
   return (
     hover.toggle && (
       <ellipse
-        clipPath="url(#clip)"
         cx={scale.x(0)}
         cy={scale.y(0)}
         rx={scale.x((hover.distance + 0.5) * 10) - scale.x(0)}

--- a/src/components/HexShotchart/index.js
+++ b/src/components/HexShotchart/index.js
@@ -70,16 +70,14 @@ const ShotChart = props => {
           <clipPath id={clipPathId}>
             <rect width={width} height={height} />
           </clipPath>
-          <rect
-            x={xScale(-250)}
-            y={yScale(417.5)}
-            width={width}
-            height={height}
-            fill={backgroundColor}
-            stroke="none"
-          />
-          <Court width={width} height={height} scale={scales} />
           <g clipPath={`url(#${clipPathId})`}>
+            <rect
+              width={width}
+              height={height}
+              fill={backgroundColor}
+              stroke="none"
+            />
+            <Court width={width} height={height} scale={scales} />
             <Hexagons
               color={color}
               data={data}

--- a/src/components/HexShotchart/index.js
+++ b/src/components/HexShotchart/index.js
@@ -66,6 +66,9 @@ const ShotChart = props => {
         preserveAspectRatio="xMidYMid meet"
       >
         <g>
+          <clipPath id="clip">
+            <rect width={width} height={height} />
+          </clipPath>
           <rect
             x={xScale(-250)}
             y={yScale(417.5)}

--- a/src/components/HexShotchart/index.js
+++ b/src/components/HexShotchart/index.js
@@ -36,6 +36,7 @@ const ShotChart = props => {
   const height = svgHeight - margin.top - margin.bottom;
   const backgroundColor = '#ddd';
   const hexbinSize = 10;
+  const clipPathId = 'hexshotchart-court-clip-path';
 
   const xScale = scaleLinear()
     .domain([-250, 250])
@@ -66,7 +67,7 @@ const ShotChart = props => {
         preserveAspectRatio="xMidYMid meet"
       >
         <g>
-          <clipPath id="clip">
+          <clipPath id={clipPathId}>
             <rect width={width} height={height} />
           </clipPath>
           <rect
@@ -78,7 +79,7 @@ const ShotChart = props => {
             stroke="none"
           />
           <Court width={width} height={height} scale={scales} />
-          <g clipPath="url(#clip)">
+          <g clipPath={`url(#${clipPathId})`}>
             <Hexagons
               color={color}
               data={data}
@@ -89,8 +90,8 @@ const ShotChart = props => {
               scale={scales}
               updateTooltip={setTooltip}
             />
+            <ShotchartCursor scale={scales} />
           </g>
-          <ShotchartCursor scale={scales} />
           {tooltip.show ? <Tooltip vals={tooltip} /> : null}
         </g>
       </Svg>

--- a/src/components/Hexagon/index.js
+++ b/src/components/Hexagon/index.js
@@ -58,19 +58,17 @@ const Hexagon = props => {
   };
 
   return (
-    <g className="hexPath">
-      <path
-        shapeRendering="geometricPrecision"
-        transform={`translate(${scale.x(x)},${scale.y(y)})`}
-        d={hexbinPath.hexagon(renderSize(radius(totalShots), hexbinSize))}
-        style={{
-          fill: color,
-        }}
-        onMouseEnter={() => setTooltip(updateTooltip, tooltipProps)}
-        onMouseLeave={() => resetTooltip(updateTooltip)}
-        onClick={() => setTooltip(updateTooltip, tooltipProps)}
-      />
-    </g>
+    <path
+      shapeRendering="geometricPrecision"
+      transform={`translate(${scale.x(x)},${scale.y(y)})`}
+      d={hexbinPath.hexagon(renderSize(radius(totalShots), hexbinSize))}
+      style={{
+        fill: color,
+      }}
+      onMouseEnter={() => setTooltip(updateTooltip, tooltipProps)}
+      onMouseLeave={() => resetTooltip(updateTooltip)}
+      onClick={() => setTooltip(updateTooltip, tooltipProps)}
+    />
   );
 };
 

--- a/src/components/Hexagons/index.js
+++ b/src/components/Hexagons/index.js
@@ -17,9 +17,8 @@ function Hexagons(props) {
   const shots = data.map(shot => [shot.x, shot.y, shot.made]);
 
   return (
-    hexbinPath(shots)
-      // .slice(0, 2)
-      .map(bin => (
+    <g className="hexagons">
+      {hexbinPath(shots).map(bin => (
         <Hexagon
           key={bin.x.toString() + bin.y.toString()}
           color={color}
@@ -31,7 +30,8 @@ function Hexagons(props) {
           scale={scale}
           updateTooltip={updateTooltip}
         />
-      ))
+      ))}
+    </g>
   );
 }
 


### PR DESCRIPTION
This PR refactors the HexShotchart child components regarding the clipPath. It also changes the clipPath to now clip the background and court too; this change is minor and results in a more accurate representation than the previous implementation.