### PR TITLE
Fix HexShotchart tooltip prop bug

### DIFF
--- a/src/components/Hexagon/index.js
+++ b/src/components/Hexagon/index.js
@@ -6,9 +6,8 @@ import {distance as euclideanDistance} from '../../lib';
 const resetTooltip = updateTooltip => {
   updateTooltip({
     color: 'none',
-    makes: '',
-    opacity: 0,
-    shots: '',
+    makes: 0,
+    shots: 0,
     show: false,
   });
 };
@@ -16,7 +15,6 @@ const resetTooltip = updateTooltip => {
 const setTooltip = (updateTooltip, props) => {
   updateTooltip({
     ...props,
-    opacity: 0.75,
     show: true,
   });
 };

--- a/src/components/Tooltip/index.js
+++ b/src/components/Tooltip/index.js
@@ -15,9 +15,8 @@ const Tooltip = props => {
         rx={5}
         ry={5}
         fill="#222"
-        fillOpacity={vals.opacity}
+        fillOpacity={0.75}
         stroke="none"
-        style={vals.opacity === 0 && {display: 'none'}}
       />
       <g>
         <rect


### PR DESCRIPTION
There was an improper style tag evaluation occurring when activating a HexShotchart tooltip introduced in ea91350c0cb6080ae35f654c98f54efba0638f0b. Upon investigation, it turns out that the `opacity` prop was actually useless since the tooltip conditionally renders using its `show` prop anyways.

Closes: #21 