### PR TITLE
Fix Hexagon bin color undefined

### DIFF
--- a/src/components/Hexagon/index.js
+++ b/src/components/Hexagon/index.js
@@ -45,7 +45,9 @@ const Hexagon = props => {
   const madeShots = data.reduce((a, b) => a + b[2], 0);
   const totalShots = data.length;
   const shootingPct = madeShots / totalShots;
-  const shootingPctAboveAvg = shootingPct - leagueShootingPct[distance];
+  const shootingPctAboveAvg =
+    shootingPct -
+    (leagueShootingPct[distance] ?? leagueShootingPct[distance - 1]);
   const color = colorScale(shootingPctAboveAvg);
 
   const tooltipProps = {

--- a/src/hooks/useShotsApi.js
+++ b/src/hooks/useShotsApi.js
@@ -5,6 +5,7 @@ import {
   binLeftRight,
   ribbonShots,
 } from '@jackfletch/splash-vis-utils';
+import isLessThanDistance from '@jackfletch/splash-vis-utils/dist/esnext/filters/isLessThanDistance';
 
 import {apiOrigin} from '../utils/config';
 
@@ -20,7 +21,7 @@ function useShotsApi(playerId, seasonId, maxDistance) {
       endpoint.pathname = `/api/shots/player/${playerId}/season/${seasonId}`;
 
       const res = await axios.get(endpoint);
-      setData(res.data);
+      setData(res.data.filter(isLessThanDistance(maxDistance)));
       setRibbonedData(ribbonShots(res.data, maxDistance));
       setBinnedData(binShots(res.data, maxDistance));
       setLeftRightData(binLeftRight(res.data, maxDistance));


### PR DESCRIPTION
As noted in 0e5c82a8a545accfde049e6a2844a4aa25d65e82, the league average lookup fails because it only fetches values up to max distance. It may make more sense to fetch league averages for all distances, which would resolve this edge case and also be more mathematically correct. If the current setup causes another bug, this alternative method should be implemented.

Closes: #29 